### PR TITLE
fix(api): is_onboarded()/validate_setup() must use ontology.entity_dirs()

### DIFF
--- a/src/diffmem/api.py
+++ b/src/diffmem/api.py
@@ -74,12 +74,24 @@ class DiffMemory:
         return self._writer_agent
 
     def is_onboarded(self) -> bool:
-        required_paths = [
-            self.user_path,
-            self.user_path / f"{self.user_id}.md",
-            self.user_path / "memories"
-        ]
-        return all(path.exists() for path in required_paths)
+        # Base structural requirements: user dir + user.md file
+        if not self.user_path.exists():
+            return False
+        if not (self.user_path / f"{self.user_id}.md").exists():
+            return False
+        # At least one ontology entity dir must exist. ADR ON-004: never
+        # hardcode "memories" — that's a personal-ontology convention, not a
+        # system invariant. Corporate uses entities/people, entities/projects,
+        # etc. The hardcoded check made every corporate-ontology user appear
+        # un-onboarded and broke every write.
+        try:
+            entity_dirs = self.ontology.entity_dirs(self.user_path)
+            if any(d.exists() for d in entity_dirs):
+                return True
+        except Exception:
+            pass
+        # Personal-ontology fallback for repos that pre-date entity_dirs.
+        return (self.user_path / "memories").exists()
 
     def onboard_user(self, user_info: str, session_id: Optional[str] = None,
                      template: str = None) -> Dict[str, Any]:
@@ -423,15 +435,27 @@ class DiffMemory:
                 'repo_path': str(self.repo_path)
             }
 
+        # Base structural requirements
         required_paths = [
             self.user_path,
             self.user_path / f"{self.user_id}.md",
-            self.user_path / "memories"
         ]
-
         for path in required_paths:
             if not path.exists():
                 issues.append(f"Missing required path: {path}")
+
+        # ADR ON-004: entity dirs come from the ontology, not a hardcode.
+        try:
+            entity_dirs = self.ontology.entity_dirs(self.user_path)
+            if not any(d.exists() for d in entity_dirs):
+                # Personal-ontology fallback: legacy worktrees may use memories/
+                if not (self.user_path / "memories").exists():
+                    issues.append(
+                        f"No entity directories found. Expected one of: "
+                        f"{[str(d) for d in entity_dirs]}"
+                    )
+        except Exception as e:
+            warnings.append(f"Could not resolve entity dirs from ontology: {e}")
 
         master_index = self.user_path / "index.md"
         if not master_index.exists():

--- a/tests/test_ontology_e2e.py
+++ b/tests/test_ontology_e2e.py
@@ -448,3 +448,111 @@ def test_plural_normalisation_safe():
     et2 = "people"
     singular2 = et2[:-1] if et2.endswith('s') else et2
     assert singular2 == "people", "no trailing s, unchanged"
+
+
+# ---------------------------------------------------------------------------
+# is_onboarded / validate_setup regression (ADR ON-004 follow-up)
+# Bug: hardcoded `self.user_path / "memories"` in is_onboarded() and
+# validate_setup() broke every write under non-personal ontologies. The
+# corporate-ontology Growth Kinetics deployment 2026-06-06 caught this in prod:
+# onboarding succeeded, the worktree was fully populated under entities/, but
+# every subsequent process-and-commit returned HTTP 500 with
+# "User has not been onboarded" because the existence check looked for
+# memories/ which doesn't exist in the corporate folder map.
+# ---------------------------------------------------------------------------
+
+def _make_user_worktree(tmp_path, user_id: str, ontology) -> Path:
+    """Helper: build a minimal worktree that matches what onboard_user would create."""
+    (tmp_path / f"{user_id}.md").write_text(f"# {user_id}\n")
+    # Create the ontology's first entity dir + one file in it (mirrors onboard).
+    first_dir = ontology.entity_dirs(tmp_path)[0]
+    first_dir.mkdir(parents=True)
+    (first_dir / "sentinel.md").write_text("# sentinel\n")
+    return tmp_path
+
+
+def test_is_onboarded_true_for_corporate_layout(tmp_path):
+    """Regression: is_onboarded() must return True when entity_dirs exist
+    (corporate ontology uses entities/, not memories/)."""
+    from diffmem.api import DiffMemory
+    p = load_ontology("corporate")
+    _make_user_worktree(tmp_path, "alex", p)
+    mem = DiffMemory(
+        repo_path=str(tmp_path), user_id="alex",
+        openrouter_api_key="dummy", model="test-model", ontology=p,
+    )
+    assert mem.is_onboarded() is True, (
+        "corporate-ontology worktree with entities/ populated must be onboarded"
+    )
+
+
+def test_is_onboarded_true_for_personal_layout(tmp_path):
+    """Regression: is_onboarded() still returns True for personal-ontology
+    worktrees using the legacy memories/ folder."""
+    from diffmem.api import DiffMemory
+    p = load_ontology("personal")
+    _make_user_worktree(tmp_path, "alex", p)
+    mem = DiffMemory(
+        repo_path=str(tmp_path), user_id="alex",
+        openrouter_api_key="dummy", model="test-model", ontology=p,
+    )
+    assert mem.is_onboarded() is True
+
+
+def test_is_onboarded_legacy_memories_fallback(tmp_path):
+    """Regression: pre-ontology worktrees (only memories/ exists, no entities/)
+    must still register as onboarded under any ontology — that's the fallback path."""
+    from diffmem.api import DiffMemory
+    p = load_ontology("personal")
+    (tmp_path / "alex.md").write_text("# alex\n")
+    (tmp_path / "memories").mkdir()
+    mem = DiffMemory(
+        repo_path=str(tmp_path), user_id="alex",
+        openrouter_api_key="dummy", model="test-model", ontology=p,
+    )
+    assert mem.is_onboarded() is True
+
+
+def test_is_onboarded_false_when_user_md_missing(tmp_path):
+    """is_onboarded must still return False when user_id.md is missing,
+    even if entity dirs exist."""
+    from diffmem.api import DiffMemory
+    p = load_ontology("corporate")
+    # Create entity dirs but no user.md
+    (p.entity_dirs(tmp_path)[0]).mkdir(parents=True)
+    mem = DiffMemory(
+        repo_path=str(tmp_path), user_id="alex",
+        openrouter_api_key="dummy", model="test-model", ontology=p,
+        auto_onboard=True,  # tmp_path exists but is empty otherwise
+    )
+    assert mem.is_onboarded() is False
+
+
+def test_is_onboarded_false_when_no_entity_dirs_and_no_memories(tmp_path):
+    """Belt-and-suspenders: with corporate ontology and no entities/ dirs AND
+    no memories/ fallback, is_onboarded must return False."""
+    from diffmem.api import DiffMemory
+    p = load_ontology("corporate")
+    (tmp_path / "alex.md").write_text("# alex\n")
+    mem = DiffMemory(
+        repo_path=str(tmp_path), user_id="alex",
+        openrouter_api_key="dummy", model="test-model", ontology=p,
+    )
+    assert mem.is_onboarded() is False
+
+
+def test_validate_setup_corporate_layout_ok(tmp_path):
+    """validate_setup() must not flag missing memories/ as an issue for a
+    properly onboarded corporate-ontology worktree."""
+    from diffmem.api import DiffMemory
+    p = load_ontology("corporate")
+    _make_user_worktree(tmp_path, "alex", p)
+    mem = DiffMemory(
+        repo_path=str(tmp_path), user_id="alex",
+        openrouter_api_key="dummy", model="test-model", ontology=p,
+    )
+    result = mem.validate_setup()
+    # OpenRouter key warning is expected (we passed dummy); entity-dir issue is the regression
+    assert "memories" not in " ".join(result["issues"]), (
+        f"validate_setup must not require memories/ under corporate ontology, got: {result['issues']}"
+    )


### PR DESCRIPTION
Closes the last two ADR ON-004 violations. Hot-fix found in production at the Growth Kinetics corporate-ontology deployment 2026-06-06 — onboarding succeeded but every subsequent process-and-commit returned HTTP 500 because is_onboarded() checked for a hardcoded `memories/` directory that doesn't exist under non-personal ontologies.

## What broke
`is_onboarded()` and `validate_setup()` both had:
```python
self.user_path / "memories"
```
in their required-paths list. Corporate ontology uses `entities/people`, `entities/projects`, etc.

## Fix
Both methods now resolve entity dirs via `self.ontology.entity_dirs(self.user_path)` and accept the legacy `memories/` directory as a fallback for personal-ontology repos that pre-date `entity_dirs`.

## Tests
- 6 new regression tests in `test_ontology_e2e.py` (corporate layout, personal layout, legacy fallback, missing user.md, no entity dirs, validate_setup non-regression)
- Full suite: 116 passed, 1 xfailed (pre-existing), zero new failures

## ADR
References ON-004 (never hardcode `memories/`, always use `entity_dirs()`).