### PR TITLE
fix(writer_agent): eliminate GitPython thread-deadlock in semantic index build

### DIFF
--- a/src/diffmem/writer_agent/agent.py
+++ b/src/diffmem/writer_agent/agent.py
@@ -705,8 +705,20 @@ class WriterAgent:
 
         return '\n'.join(result_lines)
 
-    def _build_single_entity_index(self, file_path: Path) -> Dict:
-        """Helper method to build semantic index for a single file (for parallel execution)."""
+    def _build_single_entity_index(self, file_path: Path,
+                                   git_stats: Optional[Dict[str, Any]] = None) -> Dict:
+        """Helper method to build semantic index for a single file (for parallel execution).
+
+        IMPORTANT (thread-safety): GitPython's persistent `cat-file --batch-check`
+        process is NOT thread-safe when a single Repo is shared across worker
+        threads. Calling `self._get_file_git_stats(...)` from inside a
+        ThreadPoolExecutor caused intermittent deadlocks where one worker would
+        block forever on a pipe.readline() in git/cmd.py:__get_object_header.
+
+        Callers in parallel paths MUST precompute git_stats in the parent
+        thread and pass them in. The inline fallback below remains for direct
+        callers; do not invoke this method concurrently without precomputed stats.
+        """
         try:
             # Read current file content
             with open(file_path, 'r', encoding='utf-8') as f:
@@ -715,8 +727,10 @@ class WriterAgent:
             # Strip existing semantic index if present
             content_without_index = self._strip_existing_semantic_index(original_content)
 
-            # Get git stats
-            git_stats = self._get_file_git_stats(file_path)
+            # Use precomputed git stats when provided (thread-safe path);
+            # fall back to live lookup for non-parallel callers.
+            if git_stats is None:
+                git_stats = self._get_file_git_stats(file_path)
             memory_strength = self._calculate_memory_strength(
                 git_stats['number_of_edits'],
                 git_stats['last_update']
@@ -763,21 +777,43 @@ class WriterAgent:
             }
 
     def _build_entity_indexes(self, file_paths: List[Path]):
-        """STEP 5: Builds semantic indexes for modified entity files in parallel."""
+        """STEP 5: Builds semantic indexes for modified entity files in parallel.
+
+        Thread-safety: git stats are computed SERIALLY in this (parent) thread
+        before launching the executor. Worker threads receive precomputed stats
+        and never touch `self.repo`. This eliminates the GitPython
+        persistent-process deadlock that caused the writer agent to hang
+        indefinitely on workloads with multiple modified entity files. See
+        `_build_single_entity_index` docstring for the full rationale.
+        """
         if not file_paths:
             self.logger.info("No files to index.")
             return
 
-        self.logger.info(f"Building semantic indexes for {len(file_paths)} modified files in parallel...")
+        # Pre-compute git stats serially in the parent thread. This is the
+        # cheap part of the work; gitstats per file is microseconds, while the
+        # LLM call (which IS what we parallelize) takes seconds.
+        self.logger.info(
+            f"Pre-computing git stats for {len(file_paths)} files (serial)..."
+        )
+        precomputed_stats: Dict[Path, Dict[str, Any]] = {
+            fp: self._get_file_git_stats(fp) for fp in file_paths
+        }
 
-        # Process files in parallel
+        self.logger.info(
+            f"Building semantic indexes for {len(file_paths)} modified files in parallel..."
+        )
+
+        # Process files in parallel (LLM calls only; no shared git access)
         max_workers = min(len(file_paths), self.max_concurrent_llm_calls)
         results = []
 
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            # Submit all indexing tasks
+            # Submit all indexing tasks with precomputed stats
             future_to_file = {
-                executor.submit(self._build_single_entity_index, file_path): file_path
+                executor.submit(
+                    self._build_single_entity_index, file_path, precomputed_stats[file_path]
+                ): file_path
                 for file_path in file_paths
             }
 

--- a/tests/test_writer_agent_thread_safety.py
+++ b/tests/test_writer_agent_thread_safety.py
@@ -1,0 +1,183 @@
+"""
+Regression tests for WriterAgent thread-safety around GitPython.
+
+Bug history: GitPython's persistent `cat-file --batch-check` subprocess is not
+thread-safe when a single Repo object is shared across worker threads. The
+writer agent's `_build_entity_indexes` parallel path used to call
+`_get_file_git_stats(...)` from inside a ThreadPoolExecutor, which produced
+intermittent deadlocks: one worker would block forever on a pipe.readline()
+inside `git/cmd.py:__get_object_header`, the executor would never drain via
+as_completed(), and the whole session would hang after the LLM work was done.
+
+Captured live at the Growth Kinetics corporate-ontology deployment 2026-06-06
+via py-spy dump on a stuck PID. The fix moves git stats computation OUT of the
+parallel section: stats are precomputed serially in the parent thread and
+passed into workers, so worker threads never touch `self.repo`.
+
+These tests pin the contract so the bug cannot regress silently.
+"""
+import json
+import threading
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import git
+import pytest
+
+from diffmem.writer_agent.agent import WriterAgent
+from diffmem.ontology.loader import load_ontology
+
+
+# ---------------------------------------------------------------------------
+# Test fixture: a minimal worktree + initialized git repo + WriterAgent
+# ---------------------------------------------------------------------------
+
+def _make_writer(tmp_path: Path) -> WriterAgent:
+    """Builds a WriterAgent with a real git repo and 3 entity files."""
+    # Init repo
+    repo = git.Repo.init(tmp_path)
+    repo.config_writer().set_value("user", "name", "test").release()
+    repo.config_writer().set_value("user", "email", "test@test").release()
+
+    # Minimal worktree structure (personal ontology default for this test)
+    (tmp_path / "alex.md").write_text("# alex\n")
+    (tmp_path / "index.md").write_text("# index\n")
+    memories = tmp_path / "memories" / "people"
+    memories.mkdir(parents=True)
+
+    file_paths = []
+    for name in ("alice", "bob", "carol"):
+        f = memories / f"{name}.md"
+        f.write_text(f"# {name}\n\nSome content about {name}.\n")
+        file_paths.append(f)
+
+    repo.index.add([str(f.relative_to(tmp_path)) for f in file_paths]
+                   + ["alex.md", "index.md"])
+    repo.index.commit("seed")
+
+    ontology = load_ontology("personal")
+    agent = WriterAgent(
+        str(tmp_path), "alex", "fake-key", model="test-model",
+        validate_paths=False, ontology=ontology,
+    )
+    # Attach file_paths for convenience
+    agent._test_file_paths = file_paths
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# Contract test: workers must not call _get_file_git_stats in parallel
+# ---------------------------------------------------------------------------
+
+def test_build_entity_indexes_precomputes_gitstats_serially(tmp_path):
+    """The bug fix: `_build_entity_indexes` MUST compute git stats serially
+    in the parent thread before launching the executor. Worker threads MUST
+    NOT call `_get_file_git_stats` (which touches self.repo, which is not
+    thread-safe).
+
+    We assert this by recording every thread that calls _get_file_git_stats
+    and verifying they are ALL the main thread.
+    """
+    agent = _make_writer(tmp_path)
+    caller_threads: list[int] = []
+    original = agent._get_file_git_stats
+
+    def tracking_gitstats(file_path):
+        caller_threads.append(threading.get_ident())
+        return original(file_path)
+
+    # Mock the LLM call so we don't need an API key
+    def fake_llm(system_prompt, user_prompt, is_json=False):
+        return {
+            "name": "test", "type": "human", "role": "test",
+            "strength": "Low", "hard_cues": [], "soft_cues": [],
+            "emotional_cues": [], "related_entities": [],
+        }
+
+    with patch.object(agent, '_get_file_git_stats', side_effect=tracking_gitstats), \
+         patch.object(agent, '_call_llm', side_effect=fake_llm):
+        agent._build_entity_indexes(agent._test_file_paths)
+
+    main_thread_id = threading.main_thread().ident
+    assert len(caller_threads) == 3, (
+        f"Expected 3 git stats calls (one per file), got {len(caller_threads)}"
+    )
+    for tid in caller_threads:
+        assert tid == main_thread_id, (
+            f"_get_file_git_stats called from thread {tid}, but only the "
+            f"main thread ({main_thread_id}) is allowed. This would re-introduce "
+            f"the GitPython thread-deadlock bug."
+        )
+
+
+def test_build_single_entity_index_accepts_precomputed_stats(tmp_path):
+    """_build_single_entity_index must accept a precomputed git_stats dict and
+    NOT call self._get_file_git_stats when one is provided."""
+    agent = _make_writer(tmp_path)
+    file_path = agent._test_file_paths[0]
+
+    precomputed = {"last_update": "2026-06-06 00:00:00 +0000", "number_of_edits": 7}
+
+    fake_index = {
+        "name": "alice", "type": "human", "role": "x",
+        "strength": "Low", "hard_cues": [], "soft_cues": [],
+        "emotional_cues": [], "related_entities": [],
+    }
+
+    captured_prompts = []
+
+    def capturing_llm(system_prompt, user_prompt, is_json=False):
+        captured_prompts.append(user_prompt)
+        return fake_index
+
+    with patch.object(agent, '_get_file_git_stats') as mock_stats, \
+         patch.object(agent, '_call_llm', side_effect=capturing_llm):
+        result = agent._build_single_entity_index(file_path, git_stats=precomputed)
+
+    assert result['success'] is True
+    assert mock_stats.call_count == 0, (
+        "When precomputed git_stats are passed, _build_single_entity_index "
+        "MUST NOT call _get_file_git_stats. This is the thread-safety contract."
+    )
+    # Verify the precomputed values flowed through into the LLM prompt
+    assert len(captured_prompts) == 1
+    prompt = captured_prompts[0]
+    assert "Number of Edits: 7" in prompt, (
+        f"Precomputed number_of_edits=7 did not reach the LLM prompt. "
+        f"Prompt was: {prompt[:500]}"
+    )
+    assert "2026-06-06" in prompt, (
+        "Precomputed last_update did not reach the LLM prompt."
+    )
+
+
+def test_build_single_entity_index_falls_back_to_live_lookup(tmp_path):
+    """When no precomputed stats are provided, _build_single_entity_index falls
+    back to live lookup. This preserves the contract for non-parallel callers."""
+    agent = _make_writer(tmp_path)
+    file_path = agent._test_file_paths[0]
+
+    fake_index = {
+        "name": "alice", "type": "human", "role": "x",
+        "strength": "Low", "hard_cues": [], "soft_cues": [],
+        "emotional_cues": [], "related_entities": [],
+    }
+
+    with patch.object(
+        agent, '_get_file_git_stats',
+        return_value={"last_update": "2026-06-06 00:00:00 +0000", "number_of_edits": 3},
+    ) as mock_stats, patch.object(agent, '_call_llm', return_value=fake_index):
+        result = agent._build_single_entity_index(file_path)  # no git_stats arg
+
+    assert result['success'] is True
+    assert mock_stats.call_count == 1, (
+        "Without precomputed git_stats, the live-lookup fallback path must be used."
+    )
+
+
+def test_build_entity_indexes_empty_list_is_noop(tmp_path):
+    """Empty file list returns without computing stats or launching workers."""
+    agent = _make_writer(tmp_path)
+    with patch.object(agent, '_get_file_git_stats') as mock_stats:
+        agent._build_entity_indexes([])
+    assert mock_stats.call_count == 0


### PR DESCRIPTION
## Problem

Writer agent hangs indefinitely after the last LLM call completes during the semantic-index-build phase. Caught in production at the Growth Kinetics corporate-ontology deployment 2026-06-06 — the entire 142-transcript historical load stalled on session 18.

## Root cause

`_build_single_entity_index` was running inside a `ThreadPoolExecutor` (up to 8 workers) and each worker called `_get_file_git_stats(...)` which uses `self.repo.head.commit`, `self.repo.git.log`, and `self.repo.git.rev_list`. These all route through GitPython's persistent `cat-file --batch-check` subprocess — and that IPC channel is **not thread-safe**. When two workers write to the same subprocess stdin concurrently, response lines get interleaved on stdout; one unlucky thread reads another thread's response and is then permanently stuck on `pipe.readline()`.

The hang is silent: no error, no timeout, no log line. The parent thread blocks in `as_completed()` waiting for a future that will never resolve. The per-user lock (ED-005) is never released, blocking every subsequent write for that user.

### Evidence: py-spy dump on stuck PID

```
Thread 2958295 'ThreadPoolExecutor-3_3':
    __get_object_header (git/cmd.py:1700)        <- BLOCKED
    get_object_header (git/cmd.py:1716)
    info (git/db.py:41)
    new_from_sha (git/objects/base.py:149)
    _get_object (git/refs/symbolic.py:315)
    _get_commit (git/refs/symbolic.py:324)
    commit (git/refs/symbolic.py:420)
    _get_file_git_stats (diffmem/writer_agent/agent.py:632)
    _build_single_entity_index (diffmem/writer_agent/agent.py:719)
```

7 workers completed; 1 hung forever; parent thread blocked in `as_completed` for ~8+ minutes before manual restart.

## Fix

Move git stats computation **out** of the parallel section.

- `_build_entity_indexes` now precomputes stats serially in the parent thread before launching the executor.
- `_build_single_entity_index` gains an `Optional[Dict] git_stats` kwarg. When provided (the parallel path), workers use it directly and never touch `self.repo`. When omitted (direct/non-parallel callers), it falls back to the live lookup — preserving existing API.

## Why this is the right shape

- The LLM call is the bottleneck (seconds). Git stats per file is microseconds.
- Parallelizing the bottleneck is the value; parallelizing the cheap-but-unsafe part was the bug.
- No performance regression — adds <10ms per session.
- Surgical: 2 functions changed, 1 new kwarg, no API breakage.

## Audit of other parallel sections

The writer agent has two other `ThreadPoolExecutor` sections:
- `_process_new_entities` (line ~199) calls `_create_single_entity` — touches `self.repo_path` (immutable Path) only, not `self.repo`. Safe.
- `_update_modified_files` (line ~518) calls `_update_single_file` — also touches only `self.repo_path`. Safe.

Only `_build_entity_indexes` had the bug.

## Tests

4 new regression tests in `tests/test_writer_agent_thread_safety.py`:
1. `test_build_entity_indexes_precomputes_gitstats_serially` — pins the contract. Records every thread that calls `_get_file_git_stats` during a parallel index build and asserts they are all the main thread.
2. `test_build_single_entity_index_accepts_precomputed_stats` — confirms the new kwarg flows precomputed values into the LLM prompt without re-fetching.
3. `test_build_single_entity_index_falls_back_to_live_lookup` — confirms direct callers still work.
4. `test_build_entity_indexes_empty_list_is_noop` — empty input doesn't fan out.

Full suite: **120 passed, 1 xfailed** (pre-existing), zero new failures.