### PR TITLE
feat(registry): strategy registry seam + diffmem-pro discovery (ADR-003)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ packages = [{include = "diffmem", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.10"
+# YAML frontmatter parsing (frontmatter.py imports yaml at module load)
+pyyaml = "^6.0"
 # HTTP requests for OpenRouter API
 requests = "^2.31.0"
 # OpenAI client for OpenRouter/Cerebras compatibility
@@ -62,6 +64,12 @@ hatchet = ["hatchet-sdk"]
 diffmem = "diffmem.cli:main"
 diffmem-server = "diffmem.server:main"
 diffmem-worker = "diffmem.executor.hatchet_worker:main"
+
+[tool.poetry.plugins."diffmem.strategies"]
+# Built-in strategies register under the same group external packages use
+# (ADR-003), so list_strategies() is non-empty with OSS alone and behaviour
+# is unchanged when no external package is installed.
+consolidator = "diffmem.consolidator_agent.agent:ConsolidatorAgent"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ requests
 openai
 gitpython
 python-dotenv
+# YAML frontmatter parsing (frontmatter.py)
+pyyaml

--- a/src/diffmem/api.py
+++ b/src/diffmem/api.py
@@ -11,6 +11,7 @@ from .retrieval_agent.agent import run_retrieval_agent, LLMConfig
 from .retrieval_agent.resolver import resolve_pointers
 from .consolidator_agent.agent import ConsolidatorAgent
 from .ontology.loader import OntologyProfile, load_ontology
+from .registry import get_strategy
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -313,7 +314,12 @@ class DiffMemory:
     _DEFAULT_TOOLS = ("dedupe", "redistribute", "link")
 
     def _consolidator(self) -> ConsolidatorAgent:
-        return ConsolidatorAgent(
+        # Strategy lookup goes through the registry (ADR-003): the built-in
+        # "consolidator" entry resolves to ConsolidatorAgent unless an installed
+        # package overrides it. The default registration keeps behaviour
+        # identical to today (no external package import in core).
+        strategy_cls = get_strategy("consolidator")
+        return strategy_cls(
             str(self.repo_path),
             self.user_id,
             self.openrouter_api_key,

--- a/src/diffmem/registry.py
+++ b/src/diffmem/registry.py
@@ -1,0 +1,75 @@
+# CAPABILITY: Agent/strategy registry — external extension seam (ADR-003).
+# INPUTS:  strategy name (str) for lookup; none for listing.
+# OUTPUTS: StrategyInfo metadata (list_strategies) or a loaded strategy object
+#          (get_strategy) discovered via entry-point group "diffmem.strategies".
+# CONSTRAINTS:
+#   - Core NEVER imports an external strategy package by name; discovery is
+#     purely metadata-driven via importlib.metadata.
+#   - Built-ins are registered under the SAME group in pyproject.toml, so
+#     list_strategies() is non-empty with OSS alone and runtime behaviour is
+#     identical whether or not an external package is installed.
+#   - entry_points(group=...) is the 3.10+ keyword API; this package floors at 3.10.
+"""Discoverable strategy registry for DiffMem.
+
+Strategies (agents, ontology providers, etc.) are registered under the
+entry-point group ``diffmem.strategies``. The OSS package registers its own
+built-ins there, so behaviour is unchanged when no external package is present.
+External packages (e.g. the private ``diffmem-pro``) add entries via the same
+group; the core resolves them by name without importing the package directly.
+"""
+import logging
+from dataclasses import dataclass
+from importlib.metadata import entry_points
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+ENTRY_POINT_GROUP = "diffmem.strategies"
+
+
+class StrategyNotFoundError(LookupError):
+    """Raised by get_strategy() for a name no package has registered.
+
+    A defined error (not a bare KeyError) so callers can distinguish a missing
+    strategy from unrelated lookup failures.
+    """
+
+
+@dataclass(frozen=True)
+class StrategyInfo:
+    """Metadata for a discoverable strategy. Reading it never imports the target."""
+
+    name: str
+    value: str  # "module:attr" target string, as declared in the entry point
+
+
+def _entries() -> list[Any]:
+    """Raw entry points for our group (fresh read each call; cheap metadata lookup)."""
+    return list(entry_points(group=ENTRY_POINT_GROUP))
+
+
+def list_strategies() -> list[StrategyInfo]:
+    """All registered strategies as metadata, sorted by name for deterministic order.
+
+    Does NOT load any target — safe to call to enumerate available strategies
+    without triggering imports or side effects.
+    """
+    infos = [StrategyInfo(name=e.name, value=e.value) for e in _entries()]
+    return sorted(infos, key=lambda s: s.name)
+
+
+def get_strategy(name: str) -> Any:
+    """Load and return the strategy object registered under ``name``.
+
+    Raises ``StrategyNotFoundError`` if nothing is registered under ``name`` —
+    never returns None and never raises a bare KeyError.
+    """
+    for entry in _entries():
+        if entry.name == name:
+            loaded = entry.load()
+            logger.info("STRATEGY_RESOLVED: name=%s target=%s", name, entry.value)
+            return loaded
+    known = [s.name for s in list_strategies()]
+    raise StrategyNotFoundError(
+        f"No strategy named {name!r} in group {ENTRY_POINT_GROUP!r}. Known: {known}"
+    )

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,52 @@
+# CAPABILITY: Registry seam tests (ADR-003).
+# INTENT: Prove the entry-point discovery layer works against the INSTALLED
+# package — built-ins surface via list_strategies(), get_strategy resolves and
+# loads the built-in consolidator, and unknown names raise the defined error
+# rather than returning None. These tests require diffmem to be installed
+# (entry points live in dist-info metadata), which `poetry run pytest` ensures.
+import pytest
+
+from diffmem.consolidator_agent.agent import ConsolidatorAgent
+from diffmem.registry import (
+    ENTRY_POINT_GROUP,
+    StrategyInfo,
+    StrategyNotFoundError,
+    get_strategy,
+    list_strategies,
+)
+
+
+def test_list_strategies_returns_builtin_consolidator():
+    # The OSS package registers its built-in(s) under the same group external
+    # packages use, so the registry is non-empty with OSS alone.
+    names = [s.name for s in list_strategies()]
+    assert "consolidator" in names, f"built-in 'consolidator' missing from {names}"
+
+
+def test_list_strategies_returns_metadata_without_loading():
+    infos = list_strategies()
+    assert infos, "expected at least one built-in strategy"
+    # Each entry is pure metadata (name + "module:attr" target), not a loaded obj.
+    cinfo = next(s for s in infos if s.name == "consolidator")
+    assert isinstance(cinfo, StrategyInfo)
+    assert cinfo.value == "diffmem.consolidator_agent.agent:ConsolidatorAgent"
+    # Deterministic ordering helps callers and downstream tests.
+    assert infos == sorted(infos, key=lambda s: s.name)
+
+
+def test_get_strategy_resolves_and_loads_builtin():
+    # get_strategy must actually LOAD the target, proving the built-in
+    # registration is live (not just metadata) and resolves to the consolidator.
+    loaded = get_strategy("consolidator")
+    assert loaded is ConsolidatorAgent
+
+
+def test_get_strategy_unknown_raises_defined_error():
+    # Unknown names raise the registry's own error — never None, never bare KeyError.
+    with pytest.raises(StrategyNotFoundError):
+        get_strategy("definitely-not-a-registered-strategy-xyz")
+
+
+def test_entry_point_group_is_stable():
+    # The group string is the public contract external packages register against.
+    assert ENTRY_POINT_GROUP == "diffmem.strategies"


### PR DESCRIPTION
Adds src/diffmem/registry.py: a minimal entry-point registry over group 'diffmem.strategies' (list_strategies/get_strategy), with built-in defaults registered in pyproject so behavior is unchanged when no external package is present. Wires one dispatch point through it. This is the open-core seam (ADR-003): the core never imports pro code by name; a private diffmem-pro package registers a noop_pro strategy via this group. DoD verified: noop_pro appears only when diffmem-pro is installed; built-ins always present. Private repo Growth-Kinetics/diffmem-pro created (hosted-only per ADR-002). DEFERRED: engine image integration of diffmem-pro (platform repo).