### PR TITLE
fix(ontology): corporate templates crash str.format() on literal placeholders

### DIFF
--- a/src/diffmem/ontologies/corporate/prompts/2_create_entity_file.txt
+++ b/src/diffmem/ontologies/corporate/prompts/2_create_entity_file.txt
@@ -13,13 +13,13 @@ Template by type (frontmatter + body). Use wikilinks `[[entity_name]]` for cross
 ```
 ---
 type: human
-title: {Name}
+title: {{Name}}
 status: active
 affiliation: internal            # or external_at:<client_slug>
 allocation: 1.0
-timestamp: {iso}
+timestamp: {{iso}}
 ---
-# Person: {Name}
+# Person: {{Name}}
 ## Active Context & Relationships
 ## Background & Interaction Notes
 ```
@@ -28,14 +28,14 @@ timestamp: {iso}
 ```
 ---
 type: company
-title: {OrgName}
+title: {{OrgName}}
 status: active_client            # active_client | prospect | vendor | partner | former
 relationship_to_company: active_client
 revenue_weight: high             # high | medium | low | none
 primary_contact: [[person_slug]]
-timestamp: {iso}
+timestamp: {{iso}}
 ---
-# External: {OrgName}
+# External: {{OrgName}}
 ## Engagement Scope
 ## Related Links
 ```
@@ -44,13 +44,13 @@ timestamp: {iso}
 ```
 ---
 type: project
-title: {ProjectName}
+title: {{ProjectName}}
 status: active                    # proposed | active | paused | completed | cancelled
 owning_engagement: northwind      # client slug, or internal
 company_priority: high            # high | medium | low
-timestamp: {iso}
+timestamp: {{iso}}
 ---
-# Project: {ProjectName}
+# Project: {{ProjectName}}
 ## Objectives & Scope
 ## Related Entities
 ## Open Items
@@ -60,13 +60,13 @@ timestamp: {iso}
 ```
 ---
 type: decision
-title: {DecisionName}
+title: {{DecisionName}}
 status: proposed                  # proposed | accepted | rejected | superseded
 deciders: [[person_a]], [[person_b]]
-date: {YYYY-MM-DD}
-timestamp: {iso}
+date: {{YYYY-MM-DD}}
+timestamp: {{iso}}
 ---
-# Decision: {DecisionName}
+# Decision: {{DecisionName}}
 ## Context & Problem Statement
 ## Decision Outcome
 ## Related Links

--- a/src/diffmem/ontologies/corporate/prompts/onboard_user_entity.txt
+++ b/src/diffmem/ontologies/corporate/prompts/onboard_user_entity.txt
@@ -20,9 +20,9 @@ engagements, its people, and its strategic context.
 ```
 ---
 type: company
-title: {CompanyName}
+title: {{CompanyName}}
 status: active
-timestamp: {iso}
+timestamp: {{iso}}
 ---
 # {user_id}
 

--- a/tests/test_ontology_template_rendering.py
+++ b/tests/test_ontology_template_rendering.py
@@ -1,0 +1,61 @@
+"""Regression: every ontology prompt template must .format() with ONLY the
+kwargs the agent code actually passes.
+
+Business rule protected: literal placeholders meant for the LLM (e.g. {Name},
+{CompanyName}, {YYYY-MM-DD} in example frontmatter) MUST be brace-escaped
+({{Name}}) in templates, or str.format() raises KeyError at runtime — which
+crashed corporate-ontology onboarding/entity-creation in production
+(diffMem-platform GOAL 2026-07-14-001; the deploy dodged it by switching to
+the personal ontology, violating the platform's no-workarounds constraint).
+
+If this test fails, fix the TEMPLATE (escape literals), never the caller.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+ONTOLOGIES_DIR = Path(__file__).parent.parent / "src" / "diffmem" / "ontologies"
+
+# Source of truth: the kwargs each agent call site passes to template.format().
+# Keep in sync with writer_agent/{agent,onboarding_agent}.py + retrieval_agent/agent.py.
+PASSED_KWARGS = {
+    "onboard_user_entity": {"user_id", "user_info"},
+    "onboard_identify_entities": {"user_id", "user_info"},
+    "onboard_timeline_entry": {"session_date", "session_id", "user_id"},
+    "1_identify_entities": {"memory_input", "semantic_index"},
+    "2_create_entity_file": {"entity_name", "entity_summary", "example_content",
+                             "example_file_name", "memory_input"},
+    "3_update_entity_file": {"file_path_name", "file_content", "memory_input"},
+    "4_create_timeline_entry": {"diff_text", "memory_input", "session_date", "session_id"},
+    "build_index": {"file_content", "file_path", "last_update",
+                    "memory_strength", "number_of_edits"},
+    "build_followups": {"commitment_slugs", "memory_input", "previous_other_items"},
+    "system": {"user_id", "baseline_tokens", "remaining_budget", "folder_listing"},
+}
+
+TEMPLATES = sorted(
+    p for p in ONTOLOGIES_DIR.glob("*/prompts/*.txt") if p.stem in PASSED_KWARGS
+)
+
+
+@pytest.mark.parametrize("template_path", TEMPLATES, ids=lambda p: f"{p.parent.parent.name}/{p.name}")
+def test_template_formats_with_only_passed_kwargs(template_path: Path):
+    kwargs = {k: f"<{k}>" for k in PASSED_KWARGS[template_path.stem]}
+    try:
+        rendered = template_path.format_map  # noqa: B018 — attribute check only
+    except AttributeError:
+        pass
+    rendered = template_path.read_text(encoding="utf-8").format(**kwargs)
+    assert rendered  # non-empty render, no KeyError/IndexError
+
+
+def test_no_unescaped_stray_tokens():
+    """Belt-and-braces: no single-brace token outside the passed-kwargs set."""
+    offenders = []
+    for p in TEMPLATES:
+        toks = set(re.findall(r"(?<!\{)\{([^{}\n]+)\}(?!\})", p.read_text(encoding="utf-8")))
+        bad = toks - PASSED_KWARGS[p.stem]
+        if bad:
+            offenders.append(f"{p.parent.parent.name}/{p.name}: {sorted(bad)}")
+    assert not offenders, "Escape these as {{token}}: " + "; ".join(offenders)


### PR DESCRIPTION
Corporate-ontology prompts contain literal example placeholders ({Name}, {CompanyName}, {OrgName}, {ProjectName}, {DecisionName}, {iso}, {YYYY-MM-DD}) that collide with Python str.format() — KeyError at runtime in onboarding + entity creation. This crashed corporate onboarding on the hosted platform engine (the deploy dodged it via DIFFMEM_ONTOLOGY=personal, now prohibited by the platform's no-workarounds constraint C-001).

Fix: brace-escape the literals ({{Name}}) so they render verbatim for the LLM. Adds a regression test that renders every ontology template with exactly the kwargs its call site passes. 222 tests green.